### PR TITLE
Fixed problems deploying karaf features to the central repository

### DIFF
--- a/src/main/java/org/apache/maven/plugin/gpg/GpgSignAttachedMojo.java
+++ b/src/main/java/org/apache/maven/plugin/gpg/GpgSignAttachedMojo.java
@@ -143,6 +143,7 @@ public class GpgSignAttachedMojo
                 if ( projectArtifactSignature != null )
                 {
                     signingBundles.add( new SigningBundle( artifact.getArtifactHandler().getExtension(),
+                                                           artifact.getClassifier(),
                                                            projectArtifactSignature ) );
                 }
             }


### PR DESCRIPTION
With the current (1.6) version it's not possible to deploy karaf features to the central repository. The following error occurs:

[ERROR]     * Missing Signature: '/de/mhus/osgi/mhu-karaf-feature/1.6.2/mhu-karaf-feature-1.6.2-features.xml.asc' does not exist for 'mhu-karaf-feature-1.6.2-features.xml'.

The reason is a wrong naming of the signature:

/de/mhus/osgi/mhu-karaf-feature/1.6.2/mhu-karaf-feature-1.6.2.xml.asc

The name of the classifier is missing in the name. The fix solve the problem.