### PR TITLE
[MGPG-71] - Plugin does not work with GPG on OSX based on MacGPG2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Debugging
 
 In case you run into a problem you can debug integration tests by performing the following steps:
 
-+ Run the respective integration test, e.g., `no-main-artifact`, by issueing the following command line
++ Run the respective integration test, e.g., `no-main-artifact`, by issuing the following command line
 
 ```bash
 mvn clean verify -Prun-its -Dinvoker.test=no-main-artifact -Dinvoker.mavenExecutable=mvnDebug

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,19 @@ There are some guidelines which will make applying PRs easier for us:
 
 If you plan to contribute on a regular basis, please consider filing a [contributor license agreement][cla].
 
+Debugging
+---------
+
+In case you run into a problem you can debug integration tests by performing the following steps:
+
++ Run the respective integration test, e.g., `no-main-artifact`, by issueing the following command line
+
+```bash
+mvn clean verify -Prun-its -Dinvoker.test=no-main-artifact -Dinvoker.mavenExecutable=mvnDebug
+```
+
++ Then attach the debugger of your IDE to port `8000` and proceed in the IDE.
+
 Making Trivial Changes
 ----------------------
 

--- a/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
+++ b/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
@@ -37,12 +37,11 @@ import org.codehaus.plexus.util.cli.StreamConsumer;
  */
 public class GpgVersionParser
 {
-    private final GpgVersionConsumer consumer;
+    private final GpgVersion gpgVersion;
 
-    private GpgVersionParser( GpgVersionConsumer consumer )
+    private GpgVersionParser( GpgVersion gpgVersion )
     {
-        this.consumer = consumer;
-
+        this.gpgVersion = gpgVersion;
     }
 
     public static GpgVersionParser parse( String executable )
@@ -72,13 +71,12 @@ public class GpgVersionParser
             // TODO probably a dedicated exception
         }
 
-        return new GpgVersionParser( out );
+        return new GpgVersionParser( out.gpgVersion );
     }
 
     public GpgVersion getGpgVersion()
     {
-        return consumer.gpgVersion;
-
+        return gpgVersion;
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
+++ b/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
@@ -94,6 +94,11 @@ public class GpgVersionParser
 
         private GpgVersion gpgVersion;
 
+        public GpgVersion getGpgVersion()
+        {
+            return gpgVersion;
+        }
+
         @Override
         public void consumeLine( String line )
             throws IOException

--- a/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
+++ b/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
@@ -90,7 +90,7 @@ public class GpgVersionParser
     static class GpgVersionConsumer
         implements StreamConsumer
     {
-        private final Pattern gpgVersionPattern = Pattern.compile( "gpg \\(GnuPG\\) .+" );
+        private final Pattern gpgVersionPattern = Pattern.compile( "gpg \\(GnuPG.*\\) .+" );
 
         private GpgVersion gpgVersion;
 

--- a/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
+++ b/src/main/java/org/apache/maven/plugin/gpg/GpgVersionParser.java
@@ -71,6 +71,11 @@ public class GpgVersionParser
             // TODO probably a dedicated exception
         }
 
+        if ( null == out.gpgVersion )
+        {
+            throw new RuntimeException( "Could not determine version from GnuPG executable " + cmd.getExecutable() );
+        }
+
         return new GpgVersionParser( out.gpgVersion );
     }
 

--- a/src/test/java/org/apache/maven/plugin/gpg/GpgVersionParserTest.java
+++ b/src/test/java/org/apache/maven/plugin/gpg/GpgVersionParserTest.java
@@ -1,0 +1,55 @@
+package org.apache.maven.plugin.gpg;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class GpgVersionParserTest
+{
+
+    @Test
+    public void testDefaultGnuPG() throws IOException
+    {
+        GpgVersionParser.GpgVersionConsumer consumer = new GpgVersionParser.GpgVersionConsumer();
+        consumer.consumeLine("gpg (GnuPG) 2.2.10");
+        assertNotNull( consumer.getGpgVersion() );
+    }
+
+    @Test
+    public void testMacGPG2() throws IOException
+    {
+        GpgVersionParser.GpgVersionConsumer consumer = new GpgVersionParser.GpgVersionConsumer();
+        consumer.consumeLine("gpg (GnuPG/MacGPG2) 2.2.10");
+        assertNotNull( consumer.getGpgVersion() );
+    }
+
+    @Test
+    public void testNonGnuPG() throws IOException
+    {
+        GpgVersionParser.GpgVersionConsumer consumer = new GpgVersionParser.GpgVersionConsumer();
+        consumer.consumeLine("gpg (FakeGPG) 2.2.10");
+        assertNull( consumer.getGpgVersion() );
+    }
+}

--- a/src/test/java/org/apache/maven/plugin/gpg/GpgVersionTest.java
+++ b/src/test/java/org/apache/maven/plugin/gpg/GpgVersionTest.java
@@ -30,6 +30,7 @@ public class GpgVersionTest
     {
         assertTrue( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ).isAtLeast( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ) ) );
         assertTrue( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ).isAtLeast( GpgVersion.parse( "2.1" ) ) );
+        assertTrue( GpgVersion.parse( "gpg (GnuPG/MacGPG2) 2.2.10" ).isAtLeast( GpgVersion.parse( "2.2.9" ) ) );
     }
 
 }


### PR DESCRIPTION
Fixed version string pattern to enable parsing on OSX with MacGPG2
and probably other GnuPG binary packages.