### PR TITLE
[MGPG-80] implement GpgVersion equality in adherence to comparibility

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/GpgVersion.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/GpgVersion.java
@@ -19,6 +19,7 @@ package org.apache.maven.plugins.gpg;
  * under the License.
  */
 
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -121,6 +122,30 @@ public class GpgVersion implements Comparable<GpgVersion>
         }
 
         return versionStringBuilder.toString();
+    }
+
+    @Override
+    public boolean equals( final Object other )
+    {
+        if ( this == other )
+        {
+            return true;
+        }
+
+        if ( !( other instanceof GpgVersion ) )
+        {
+            return false;
+        }
+
+        final GpgVersion that = (GpgVersion) other;
+
+        return compareTo( that ) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Arrays.hashCode( versionSegments );
     }
 
 }

--- a/src/test/java/org/apache/maven/plugins/gpg/GpgVersionConsumerTest.java
+++ b/src/test/java/org/apache/maven/plugins/gpg/GpgVersionConsumerTest.java
@@ -34,7 +34,7 @@ public class GpgVersionConsumerTest
         GpgVersionConsumer consumer = new GpgVersionConsumer();
         consumer.consumeLine( "gpg (GnuPG/MacGPG2) 2.2.10" );
 
-        assertThat( consumer.getGpgVersion().toString(), is( GpgVersion.parse( "2.2.10" ).toString() ) );
+        assertThat( consumer.getGpgVersion(), is( GpgVersion.parse( "2.2.10" ) ) );
     }
 
 }

--- a/src/test/java/org/apache/maven/plugins/gpg/GpgVersionTest.java
+++ b/src/test/java/org/apache/maven/plugins/gpg/GpgVersionTest.java
@@ -21,7 +21,9 @@ package org.apache.maven.plugins.gpg;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -48,4 +50,25 @@ public class GpgVersionTest
         assertFalse( GpgVersion.parse( "gpg (GnuPG) 2.0.26 (Gpg4win 2.2.3)" )
                 .isBefore( GpgVersion.parse( "2.0.26" ) ) );
     }
+
+    @Test
+    public void testEquality()
+    {
+        assertEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ), GpgVersion.parse( "gpg (GnuPG) 2.2.1" ) );
+        assertEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ), GpgVersion.parse( "2.2.1" ) );
+        assertEquals( GpgVersion.parse( "gpg (GnuPG/MacGPG2) 2.2.10" ), GpgVersion.parse( "2.2.10" ) );
+        assertEquals( GpgVersion.parse( "gpg (GnuPG) 2.0.26 (Gpg4win 2.2.3)" ), GpgVersion.parse( "2.0.26" ) );
+
+        assertEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ).hashCode(), GpgVersion.parse( "gpg (GnuPG) 2.2.1" ).hashCode() );
+        assertEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ).hashCode(), GpgVersion.parse( "2.2.1" ).hashCode() );
+        assertEquals( GpgVersion.parse( "gpg (GnuPG/MacGPG2) 2.2.10" ).hashCode(), GpgVersion.parse( "2.2.10" ).hashCode() );
+        assertEquals( GpgVersion.parse( "gpg (GnuPG) 2.0.26 (Gpg4win 2.2.3)" ).hashCode(), GpgVersion.parse( "2.0.26" ).hashCode() );
+
+        assertNotEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ), GpgVersion.parse( "2.2.0" ) );
+        assertNotEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ), GpgVersion.parse( "2.2" ) );
+
+        assertNotEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ).hashCode(), GpgVersion.parse( "2.2.0" ).hashCode() );
+        assertNotEquals( GpgVersion.parse( "gpg (GnuPG) 2.2.1" ).hashCode(), GpgVersion.parse( "2.2" ).hashCode() );
+    }
+
 }


### PR DESCRIPTION
Provides an implementation of GpgVersion#equals andGpgVersion#hashCode to address [MGPG-80](https://issues.apache.org/jira/projects/MGPG/issues/MGPG-80).
"GpgVersion#equals" is implemented by utilizing "GpgVersion#compareTo".
