### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojo.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojo.java
@@ -30,7 +30,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
-import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
@@ -201,7 +200,7 @@ public abstract class AbstractGpgMojo extends AbstractMojo {
      * @throws MojoFailureException
      */
     private void loadGpgPassphrase() throws MojoFailureException {
-        if (StringUtils.isEmpty(this.passphrase)) {
+        if (this.passphrase == null || this.passphrase.isEmpty()) {
             Server server = this.settings.getServer(passphraseServerId);
 
             if (server != null) {

--- a/src/main/java/org/apache/maven/plugins/gpg/GpgSigner.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/GpgSigner.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.Os;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -51,7 +50,7 @@ public class GpgSigner extends AbstractGpgSigner {
 
         Commandline cmd = new Commandline();
 
-        if (StringUtils.isNotEmpty(executable)) {
+        if (executable != null && !executable.isEmpty()) {
             cmd.setExecutable(executable);
         } else {
             cmd.setExecutable("gpg" + (Os.isFamily(Os.FAMILY_WINDOWS) ? ".exe" : ""));
@@ -137,7 +136,7 @@ public class GpgSigner extends AbstractGpgSigner {
             cmd.createArg().setValue("--no-default-keyring");
         }
 
-        if (StringUtils.isNotEmpty(secretKeyring)) {
+        if (secretKeyring != null && !secretKeyring.isEmpty()) {
             if (gpgVersion.isBefore(GpgVersion.parse("2.1"))) {
                 cmd.createArg().setValue("--secret-keyring");
                 cmd.createArg().setValue(secretKeyring);
@@ -147,7 +146,7 @@ public class GpgSigner extends AbstractGpgSigner {
             }
         }
 
-        if (StringUtils.isNotEmpty(publicKeyring)) {
+        if (publicKeyring != null && !publicKeyring.isEmpty()) {
             cmd.createArg().setValue("--keyring");
             cmd.createArg().setValue(publicKeyring);
         }

--- a/src/main/java/org/apache/maven/plugins/gpg/GpgVersionParser.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/GpgVersionParser.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.Os;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -57,7 +56,7 @@ public class GpgVersionParser {
     public static GpgVersionParser parse(String executable) throws MojoExecutionException {
         Commandline cmd = new Commandline();
 
-        if (StringUtils.isNotEmpty(executable)) {
+        if (executable != null && !executable.isEmpty()) {
             cmd.setExecutable(executable);
         } else {
             cmd.setExecutable("gpg" + (Os.isFamily(Os.FAMILY_WINDOWS) ? ".exe" : ""));


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu