### PR TITLE
[MGPG-110] SignAndDeployFileMojo validation is off

### DIFF
--- a/src/it/sign-release-with-excludes/verify.groovy
+++ b/src/it/sign-release-with-excludes/verify.groovy
@@ -30,6 +30,12 @@ var expectedFiles = [
 
 for (File file : artifactDir.listFiles()) {
     var fileName = file.getName()
+
+    //maven4: skip consumer POM
+    if (fileName.endsWith("consumer.pom") || fileName.endsWith("consumer.pom.asc")) {
+        continue
+    }
+
     println "Checking if file is expected: $file"
 
     var expected = false;

--- a/src/main/java/org/apache/maven/plugins/gpg/SignAndDeployFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/SignAndDeployFileMojo.java
@@ -456,7 +456,7 @@ public class SignAndDeployFileMojo extends AbstractGpgMojo {
         Model model = generateModel();
 
         ModelBuildingRequest request =
-                new DefaultModelBuildingRequest().setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0);
+                new DefaultModelBuildingRequest().setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_STRICT);
 
         List<String> result = new ArrayList<>();
 


### PR DESCRIPTION
It was validating POMs as "Maven2". These POMs should be handled as "new projects" and they must have strict validation in effect instead. Still, given "strict" validation is a moving target (it depends on currently running Maven version), we need to factor in Maven4 as well. Once beta, Maven4 should be added to build matrix. Currently was running locally the build with latest alpha-13 SNAPSHOT (it went OK) that showed one IT that was sensitive to it, fixed in this PR as well.

---

https://issues.apache.org/jira/browse/MGPG-110