### PR TITLE
[MGPG-113] SignAndDeployFileMojo results in 401

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojo.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojo.java
@@ -258,8 +258,6 @@ public abstract class AbstractGpgMojo extends AbstractMojo {
     @Component
     protected MavenSession session;
 
-    // === Deprecated stuff
-
     /**
      * Switch to improve plugin enforcement of "best practices". If set to {@code false}, plugin retains all the
      * backward compatibility regarding getting secrets (but will warn). If set to {@code true}, plugin will fail
@@ -280,7 +278,7 @@ public abstract class AbstractGpgMojo extends AbstractMojo {
      * @since 1.6
      */
     @Parameter(defaultValue = "${settings}", readonly = true, required = true)
-    private Settings settings;
+    protected Settings settings;
 
     /**
      * Maven Security Dispatcher.

--- a/src/main/java/org/apache/maven/plugins/gpg/SignAndDeployFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/SignAndDeployFileMojo.java
@@ -142,15 +142,6 @@ public class SignAndDeployFileMojo extends AbstractGpgMojo {
     private String repositoryId;
 
     /**
-     * The type of remote repository layout to deploy to. Try <i>legacy</i> for a Maven 1.x-style repository layout.
-     *
-     * @deprecated Maven3 does not support "legacy" (Maven1) layout anymore. This parameter is unused.
-     */
-    @Deprecated
-    @Parameter(property = "repositoryLayout", defaultValue = "default")
-    private String repositoryLayout;
-
-    /**
      * The bundled API docs for the artifact.
      *
      * @since 1.3


### PR DESCRIPTION
The RemoteRepository was "bare", it has to be equipped with AuthenticationSelector to be able to perform authenticated deploys. Also, remove "layout" as since Maven 3.0 there is no other layout than "default".

Also, a bit of tidy up, layout is deprecated in Maven3 and is unused.

---

https://issues.apache.org/jira/browse/MGPG-113