### PR TITLE
[MGPG-114] Allow max key size of 16KB

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
@@ -123,7 +123,7 @@ public class BcSigner extends AbstractGpgSigner {
         /**
          * Maximum key size, see <a href="https://wiki.gnupg.org/LargeKeys">Large Keys</a>.
          */
-        private static final long MAX_SIZE = 5 * 1024 + 1L;
+        private static final long MAX_SIZE = 16 * 1024 + 1L;
 
         @Override
         public byte[] loadKeyRingMaterial(RepositorySystemSession session) throws IOException {
@@ -137,7 +137,7 @@ public class BcSigner extends AbstractGpgSigner {
                 if (Files.size(keyPath) < MAX_SIZE) {
                     return Files.readAllBytes(keyPath);
                 } else {
-                    throw new IOException("Refusing to load key " + keyPath + "; is larger than 5KB");
+                    throw new IOException("Refusing to load key " + keyPath + "; is larger than 16KB");
                 }
             }
             return null;


### PR DESCRIPTION
This insanely huge key size is mentioned as some extreme example on page https://wiki.gnupg.org/LargeKeys

---

https://issues.apache.org/jira/browse/MGPG-114
