### PR TITLE
[MGPG-116] Up max key file size to 64K

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
@@ -143,7 +143,7 @@ public class BcSigner extends AbstractGpgSigner {
                 if (Files.size(keyPath) < MAX_SIZE) {
                     return Files.readAllBytes(keyPath);
                 } else {
-                    throw new IOException("Refusing to load key " + keyPath + "; is larger than 16KB");
+                    throw new IOException("Refusing to load key " + keyPath + "; is larger than 64KB");
                 }
             }
             return null;

--- a/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
@@ -122,9 +122,14 @@ public class BcSigner extends AbstractGpgSigner {
 
     public final class GpgConfLoader implements Loader {
         /**
-         * Maximum key size, see <a href="https://wiki.gnupg.org/LargeKeys">Large Keys</a>.
+         * Maximum file size allowed to load (as we load it into heap).
+         * <p>
+         * This barrier exists to prevent us to load big/huge files, if this code is pointed at one
+         * (by mistake or by malicious intent).
+         *
+         * @see <a href="https://wiki.gnupg.org/LargeKeys">Large Keys</a>
          */
-        private static final long MAX_SIZE = 16 * 1024 + 1L;
+        private static final long MAX_SIZE = 64 * 1024 + 1L;
 
         @Override
         public byte[] loadKeyRingMaterial(RepositorySystemSession session) throws IOException {

--- a/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/BcSigner.java
@@ -143,7 +143,7 @@ public class BcSigner extends AbstractGpgSigner {
                 if (Files.size(keyPath) < MAX_SIZE) {
                     return Files.readAllBytes(keyPath);
                 } else {
-                    throw new IOException("Refusing to load key " + keyPath + "; is larger than 64KB");
+                    throw new IOException("Refusing to load file " + keyPath + "; is larger than 64KB");
                 }
             }
             return null;


### PR DESCRIPTION
Allow 64K files as well, as this may be "ring" (collection of keys) as well.

---

https://issues.apache.org/jira/browse/MGPG-116