### PR TITLE
[MGPG-140] Update Maven to 3.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@ under the License.
 
   <properties>
     <javaVersion>8</javaVersion>
-    <mavenVersion>3.9.6</mavenVersion>
-    <resolverVersion>1.9.18</resolverVersion>
+    <mavenVersion>3.9.9</mavenVersion>
+    <resolverVersion>1.9.22</resolverVersion>
     <bouncycastleVersion>1.78.1</bouncycastleVersion>
     <project.build.outputTimestamp>2024-08-08T19:07:22Z</project.build.outputTimestamp>
     <resource.delimiter>@</resource.delimiter>


### PR DESCRIPTION
This is really just "build time" as at runtime it uses given Maven version artifacts anyway.

---

https://issues.apache.org/jira/browse/MGPG-140