### PR TITLE
Don't use empty string as an attached artifact classifier

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/GpgSignAttachedMojo.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/GpgSignAttachedMojo.java
@@ -100,11 +100,13 @@ public class GpgSignAttachedMojo extends AbstractGpgMojo {
 
             File signature = signer.generateSignatureForArtifact(item.getFile());
 
+            String classifier = item.getClassifier();
+            // FilesCollector generates items with an empty classifier when the original artifact used null.
+            // Prefer null as other plugins may have problems with project attachments with "" as the classifier
+            classifier = classifier == null || classifier.isEmpty() ? null : classifier;
+
             projectHelper.attachArtifact(
-                    project,
-                    item.getExtension() + AbstractGpgSigner.SIGNATURE_EXTENSION,
-                    item.getClassifier(),
-                    signature);
+                    project, item.getExtension() + AbstractGpgSigner.SIGNATURE_EXTENSION, classifier, signature);
         }
     }
 }


### PR DESCRIPTION
Resolves #138 

Note that perhaps the correction for this should be in the FilesCollector.Item constructor. That's a public class though so I didn't want to change its behavior. The only use of Item is in GpgSignAttachedMojo though, so it should be safe to change. If you're interested in fixing this I'd be happy to change this PR to do it that way, if you want.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ X] Your pull request should address just one issue, without pulling in other changes.
- [ X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.

Not really practical.

- [X ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ X] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
