### PR TITLE
Make empty classifier null (not empty string)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/FilesCollector.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/FilesCollector.java
@@ -119,10 +119,7 @@ public class FilesCollector {
                 continue;
             }
 
-            items.add(new Item(
-                    file,
-                    artifact.getClassifier().trim().isEmpty() ? null : artifact.getClassifier(),
-                    artifact.getExtension()));
+            items.add(new Item(file, artifact.getClassifier(), artifact.getExtension()));
         }
 
         return items;
@@ -157,7 +154,7 @@ public class FilesCollector {
 
         public Item(File file, String classifier, String extension) {
             this.file = requireNonNull(file);
-            this.classifier = classifier; // nullable
+            this.classifier = classifier == null || classifier.trim().isEmpty() ? null : classifier; // nullable
             this.extension = requireNonNull(extension);
         }
 


### PR DESCRIPTION
And be consistent: as some legacy stuff in Maven and around (plugins) perform just nullcheck and not also empty string check, and get confused on empty string classifier. Plugins are (should) not be reused as dependencies, so despite the helper class is `public` I see no harm to alter it.

Supersedes #135 
Fixes #138 