### PR TITLE
Let the excludes IT see the POM pair Maven 4 installs

### DIFF
--- a/src/it/sign-release-with-excludes/verify.groovy
+++ b/src/it/sign-release-with-excludes/verify.groovy
@@ -22,6 +22,9 @@ var expectedFiles = [
     "_remote.repositories",
     "test-1.0.pom",
     "test-1.0.pom.asc",
+    // maven4 installs the build POM next to the consumer POM, and signs both
+    "test-1.0-build.pom",
+    "test-1.0-build.pom.asc",
     "test-1.0.jar",
     "test-1.0.jar.asc",
     "test-1.0-sources.jar",
@@ -30,11 +33,6 @@ var expectedFiles = [
 
 for (File file : artifactDir.listFiles()) {
     var fileName = file.getName()
-
-    //maven4: skip consumer POM
-    if (fileName.endsWith("consumer.pom") || fileName.endsWith("consumer.pom.asc")) {
-        continue
-    }
 
     println "Checking if file is expected: $file"
 


### PR DESCRIPTION
`sign-release-with-excludes` fails under Maven 4 with:

```
java.lang.Exception: Unexpected file .../org/apache/maven/its/gpg/srwe/test/1.0/test-1.0-build.pom.asc
```

Maven 4 installs a build POM alongside the consumer POM, and `gpg:sign` signs both, so four POM files reach the local repository where Maven 3 puts two:

```
maven 3                    maven 4
_remote.repositories       _remote.repositories
                           test-1.0-build.pom        <- new
                           test-1.0-build.pom.asc    <- new
test-1.0.jar               test-1.0.jar
test-1.0.jar.asc           test-1.0.jar.asc
test-1.0.pom               test-1.0.pom
test-1.0.pom.asc           test-1.0.pom.asc
```

Those two are the only new files; the rest of the directory is unchanged.

### Why this IT and not the others

Ten of the ITs that keep an `expectedFiles` list iterate the list and assert each file exists, so extra files never bother them. This one iterates `artifactDir.listFiles()` and rejects anything not on the list. That inversion is deliberate: the project runs `gpg:sign` twice, and the point is to prove the second run does not sign the first run's signatures. A presence check cannot show the absence of a `.asc.asc`.

So the fix adds the two names to `expectedFiles` rather than adding a second `continue`. Every skip is a hole in the one check whose value is that it is exhaustive. The names cost nothing on Maven 3, which installs neither.

### The removed clause

```groovy
//maven4: skip consumer POM
if (fileName.endsWith("consumer.pom") || fileName.endsWith("consumer.pom.asc")) {
```

This has stopped matching anything. It arrived with 0771b61 ([MGPG-110], March 2024), when Maven 4 installed the consumer POM as `*-consumer.pom`. Maven 4 now installs the consumer POM under the plain `test-1.0.pom` name, and it is the *build* POM that carries a suffix — so the guard silently stopped guarding. Dropping it leaves one mechanism instead of two.

If a Maven 4 version that still installs `*-consumer.pom` is ever added to the matrix this would need revisiting, but the matrix is 4.0.0-rc-6 and 3.10.0-rc-1 today.

### Verification

Ran the IT locally against both, cleaning `target` between runs:

| | Maven 3.9.16 | Maven 4 |
| --- | --- | --- |
| before | passes | **fails** — `Unexpected file …test-1.0-build.pom.asc` |
| after | passes | passes |

Both invoker executions (the `gpg` signer and the `bc` signer) pass in each green run.

### Follow-up, not in this PR

Unlike its ten siblings, this IT never asserts that the expected files are *present* — it only rejects extras, so it would pass if gpg signed nothing at all. Worth adding, but it is a change to what the test proves rather than a Maven 4 fix.

This unblocks #330, which turns the Maven 4 matrix leg on and is currently red for exactly this reason.
