### PR TITLE
Keep the FAQ quotation marks straight

### DIFF
--- a/src/site/markdown/faq.md
+++ b/src/site/markdown/faq.md
@@ -27,7 +27,7 @@ under the License.
 
 1. [What is GnuPG?](#question1)
 2. [Why is the site descriptor not signed?](#site-descriptor)
-3. [Why am I getting "gpg: signing failed: No pinentry" while releasing?](#no-pinentry)
+3. [Why am I getting &quot;gpg: signing failed: No pinentry&quot; while releasing?](#no-pinentry)
 
 <a id="question1"></a>
 
@@ -46,10 +46,10 @@ Maven Site Plugin 2.1.1+ which contains the required fix (see also
 
 <a id="no-pinentry"></a>
 
-### Why am I getting "gpg: signing failed: No pinentry" while releasing?
+### Why am I getting &quot;gpg: signing failed: No pinentry&quot; while releasing?
 
 When plugin used in combination with
 [Maven Release Plugin](https://maven.apache.org/maven-release/maven-release-plugin/) the GPG signing will
-happen in "batch mode". This implies that you must either use GPG passphrase passed in via environment
+happen in &quot;batch mode&quot;. This implies that you must either use GPG passphrase passed in via environment
 variable (preferred on systems like CI systems are), or, if on Workstation, using primed gpg-agent is needed.
 Read more here about [GPG Agent priming](passphrase.html#Retrieve_passphrase_via_gpg-agent).


### PR DESCRIPTION
Follow-up to #335, which converted this FAQ from FML to Markdown.

FML is XML, so it rendered quotation marks exactly as written. Markdown goes through flexmark, whose smart-punctuation extension rewrites a bare `"` into a typographic pair - so the converted page silently changed the visible text:

| | rendered |
|---|---|
| before (FML) | `"gpg: signing failed: No pinentry"` |
| after (Markdown) | curly-quoted |

Three pairs in total. It matters here because both quoted strings are things a reader copies: the literal error message people paste into a search engine, and a mode name.

Writing `&quot;` in the Markdown source keeps them straight. That is the convention the already-converted pages in `maven-site-plugin` use.

**Verified** by rebuilding and comparing against the original FML rendering: the quotation marks match again, no anchor changed, and the page is otherwise identical.

<sub>Drafted with Claude - please verify</sub>
