### PR TITLE
Clarify that sign-and-deploy-file uses Resolver POST

### DIFF
--- a/src/main/java/org/apache/maven/plugins/gpg/SignAndDeployFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/gpg/SignAndDeployFileMojo.java
@@ -59,6 +59,11 @@ import org.eclipse.aether.repository.RemoteRepository;
 /**
  * Signs artifacts and deploys the artifacts and signatures in the remote repository.
  *
+ * <p>Deployment uses Maven Resolver's HTTP POST deploy API. That is not accepted by every remote
+ * repository. If your host rejects it, sign with {@code gpg:sign} and deploy with a tool that
+ * speaks the repository's own API, for example
+ * <a href="https://github.com/maveniverse/njord">Njord</a>.
+ *
  * @author Daniel Kulp
  * @since 1.0-beta-4
  */

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -30,7 +30,7 @@ This plugin signs artifacts according to [OpenPGP standard](https://www.ietf.org
 #[[##]]# Goals Overview
 
 - [gpg:sign](./sign-mojo.html) Sign project artifact, the POM, and attached artifacts with GnuPG for deployment.
-- [gpg:sign-and-deploy-file](./sign-and-deploy-file-mojo.html) Signs artifacts and installs the artifact in the remote repository.
+- [gpg:sign-and-deploy-file](./sign-and-deploy-file-mojo.html) Signs artifacts and deploys them with Maven Resolver HTTP POST. Not every remote repository accepts that deploy API; see [Njord](https://github.com/maveniverse/njord) for an alternative.
 - [gpg:sign-deployed](./sign-deployed-mojo.html) Resolves given artifacts from a given remote repository, signs them, and deploys the signatures next to signed artifacts.
 
 #[[##]]# Usage


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

The generated `sign-and-deploy-file` page only said it signs and deploys. It now says deployment is Maven Resolver HTTP POST (not every host accepts that) and points at Njord. I did not deprecate the goal.

Fixes #296
